### PR TITLE
TE-8297 strict URL validation

### DIFF
--- a/src/Spryker/Zed/Auth/Communication/Plugin/EventDispatcher/RedirectAfterLoginEventDispatcherPlugin.php
+++ b/src/Spryker/Zed/Auth/Communication/Plugin/EventDispatcher/RedirectAfterLoginEventDispatcherPlugin.php
@@ -157,7 +157,7 @@ class RedirectAfterLoginEventDispatcherPlugin extends AbstractPlugin implements 
             return null;
         }
 
-        if (substr($url, 0, 1) !== '/' || substr($url, 0, 2) === '//') {
+        if (substr($url, 0, 1) !== '/' || substr($url, 0, 2) === '//' || strpos($url, '\\') !== false) {
             return null;
         }
 

--- a/src/Spryker/Zed/Auth/Communication/Plugin/ServiceProvider/RedirectAfterLoginProvider.php
+++ b/src/Spryker/Zed/Auth/Communication/Plugin/ServiceProvider/RedirectAfterLoginProvider.php
@@ -151,7 +151,7 @@ class RedirectAfterLoginProvider extends AbstractPlugin implements ServiceProvid
             return null;
         }
 
-        if (substr($url, 0, 1) !== '/' || substr($url, 0, 2) === '//') {
+        if (substr($url, 0, 1) !== '/' || substr($url, 0, 2) === '//' || strpos($url, '\\') !== false) {
             return null;
         }
 

--- a/tests/SprykerTest/Zed/Auth/Communication/Plugin/EventDispatcher/RedirectAfterLoginEventDispatcherPluginTest.php
+++ b/tests/SprykerTest/Zed/Auth/Communication/Plugin/EventDispatcher/RedirectAfterLoginEventDispatcherPluginTest.php
@@ -142,6 +142,7 @@ class RedirectAfterLoginEventDispatcherPluginTest extends Unit
      */
     public function testOnKernelResponseShouldNotUseInvalidRefererWithoutHttp(): void
     {
+        // Arrange
         $kernel = $this->getHttpKernel();
 
         $request = new Request();
@@ -150,6 +151,7 @@ class RedirectAfterLoginEventDispatcherPluginTest extends Unit
         $response = new RedirectResponse(AuthConfig::DEFAULT_URL_REDIRECT);
         $event = new ResponseEvent($kernel, $request, HttpKernelInterface::MASTER_REQUEST, $response);
 
+        // Act
         $redirectAfterLoginEventDispatcherPlugin = $this->getRedirectAfterLoginEventDispatcherPlugin(['isAuthenticated']);
         $redirectAfterLoginEventDispatcherPlugin->expects($this->once())
             ->method('isAuthenticated')
@@ -157,6 +159,7 @@ class RedirectAfterLoginEventDispatcherPluginTest extends Unit
 
         $event = $this->dispatchEvent($event, $redirectAfterLoginEventDispatcherPlugin);
 
+        // Assert
         $this->assertSame('/', $event->getResponse()->headers->get('location'));
     }
 

--- a/tests/SprykerTest/Zed/Auth/Communication/Plugin/ServiceProvider/RedirectAfterLoginProviderTest.php
+++ b/tests/SprykerTest/Zed/Auth/Communication/Plugin/ServiceProvider/RedirectAfterLoginProviderTest.php
@@ -135,13 +135,16 @@ class RedirectAfterLoginProviderTest extends Unit
      */
     public function testOnKernelResponseShouldNotUseInvalidRefererWithoutHttp(): void
     {
+        // Arrange
         $kernel = $this->getHttpKernel();
+        
         $request = new Request();
         $request->server->set(static::REQUEST_URI, AuthConfig::DEFAULT_URL_LOGIN);
         $request->query->set(RedirectAfterLoginProvider::REFERER, static::REDIRECT_URL_INVALID_WITHOUT_HTTP);
         $response = new RedirectResponse(AuthConfig::DEFAULT_URL_REDIRECT);
         $event = new ResponseEvent($kernel, $request, HttpKernelInterface::MASTER_REQUEST, $response);
 
+        // Act
         $redirectAfterLoginProvider = $this->getRedirectAfterLoginProvider(['isAuthenticated']);
         $redirectAfterLoginProvider->expects($this->once())
             ->method('isAuthenticated')
@@ -149,6 +152,7 @@ class RedirectAfterLoginProviderTest extends Unit
 
         $redirectAfterLoginProvider->onKernelResponse($event);
 
+        // Assert
         $this->assertSame('/', $event->getResponse()->headers->get('location'));
     }
 


### PR DESCRIPTION
- Developer(s): @Nidhognit

- Ticket: https://spryker.atlassian.net/browse/TE-8297

#### Release Table

   Module                | Release Type         | Constraint Updates         |
   :--------------------- | :------------------------ | :--------------------- |
   Auth                   | patch                 |                       |

-----------------------------------------

#### Module Auth

##### Change log

Fixes

- Adjusted `RedirectAfterLoginProvider` to make `referer` field validation more strict.
- Adjusted `RedirectAfterLoginEventDispatcherPlugin` to make `referer` field validation more strict.

